### PR TITLE
fix: resolve [object Object] in generated CLAUDE.md import graph

### DIFF
--- a/packages/ai-context/src/claude-md-generator.ts
+++ b/packages/ai-context/src/claude-md-generator.ts
@@ -646,7 +646,7 @@ export class ClaudeMdGenerator {
             const name = mod?.name || moduleId
             lines.push(`### ${name}`)
             for (const f of files) {
-                const imports = f.imports!.map(imp => `\`${imp}\``).join(', ')
+                const imports = f.imports!.map(imp => `\`${typeof imp === 'string' ? imp : imp.source}\``).join(', ')
                 lines.push(`- \`${f.path}\` → ${imports}`)
             }
             lines.push('')

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -26,7 +26,7 @@ interface LockFunction {
     returnType?: string; purpose?: string
     calls: string[]; calledBy: string[]; hash: string
 }
-interface LockFile { path: string; moduleId?: string; hash?: string; imports?: string[]; lastModified?: string }
+interface LockFile { path: string; moduleId?: string; hash?: string; imports?: (string | { source: string; resolvedPath?: string; names?: string[] })[]; lastModified?: string }
 
 // ─── Data Provider ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Import objects ({source, resolvedPath}) were being string-interpolated directly in template literals, producing `[object Object]` instead of the actual package name. Extract `.source` from import objects when generating the File Import Graph section.

Also fix the LockFile type in the VS Code extension to match the actual lock file schema (imports are objects, not strings).

## What this changes

<!-- One paragraph. What problem does this PR solve? -->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Parser improvement
- [ ] Performance
- [ ] Docs / README
- [ ] Refactor

## How to test

```bash
# Commands to verify the fix
cd packages/core
bun test

mikk analyze
mikk ci
```

## Test project

<!-- If this affects parsing or analysis, describe the test case -->

## Checklist

- [x] `bun run build` passes with no TypeScript errors
- [x] `bun run test` passes (363+ tests, 0 failures)
- [ ] If parser change: tested against real TypeScript / JS / Go code
- [ ] If MCP tool change: tested with an actual MCP client session
- [ ] If constraint change: `mikk ci` correctly exits non-zero on violations
- [ ] Lock file format unchanged (or migration path documented)
- [ ] README updated if behavior changed

## Breaking changes

<!-- Does this change the lock file format, CLI flags, MCP tool output schema, or mikk.json schema? -->
None / describe here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import graph generation to properly handle and display enhanced import metadata, including source paths and resolved file locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->