### PR TITLE
fix: use dynamic import for oxc-parser to support ESM-only versions

### DIFF
--- a/.changeset/oxc-parser-esm-fix.md
+++ b/.changeset/oxc-parser-esm-fix.md
@@ -1,0 +1,5 @@
+---
+"@getmikk/core": patch
+---
+
+Use dynamic import for oxc-parser to support ESM-only versions (0.121.0+)

--- a/packages/core/src/parser/oxc-parser.ts
+++ b/packages/core/src/parser/oxc-parser.ts
@@ -1,5 +1,4 @@
 import path from 'node:path';
-import { parseSync } from 'oxc-parser';
 import { BaseParser } from './base-parser.js';
 import { OxcResolver } from './oxc-resolver.js';
 import { hashContent } from '../hash/file-hasher.js';
@@ -283,6 +282,7 @@ export class OxcParser extends BaseParser {
 
         let ast: any;
         try {
+            const { parseSync } = await import('oxc-parser');
             const result = parseSync(filePath, content, {
                 sourceType: 'module',
                 lang: isTS ? 'ts' : 'js',


### PR DESCRIPTION
oxc-parser@0.121.0 ships as ESM-only ("type": "module"), but the CLI bundles to CJS format, causing `require("oxc-parser")` to fail with ERR_REQUIRE_ESM. Switch to async `await import('oxc-parser')` inside the already-async `parse()` method.

## What this changes

<!-- One paragraph. What problem does this PR solve? -->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Parser improvement
- [ ] Performance
- [ ] Docs / README
- [ ] Refactor

## How to test

```bash
# Commands to verify the fix
cd packages/core
bun test

mikk analyze
mikk ci
```

## Test project

<!-- If this affects parsing or analysis, describe the test case -->

## Checklist

- [x] `bun run build` passes with no TypeScript errors
- [x] `bun run test` passes (363+ tests, 0 failures)
- [ ] If parser change: tested against real TypeScript / JS / Go code
- [ ] If MCP tool change: tested with an actual MCP client session
- [ ] If constraint change: `mikk ci` correctly exits non-zero on violations
- [ ] Lock file format unchanged (or migration path documented)
- [ ] README updated if behavior changed

## Breaking changes

<!-- Does this change the lock file format, CLI flags, MCP tool output schema, or mikk.json schema? -->
None / describe here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Parser now resolves a required dependency at runtime to improve compatibility with modern module builds; behavior and error handling remain unchanged.
* **Chore**
  * Patch-level package update recorded to reflect this compatibility adjustment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->